### PR TITLE
Restore ability to use on(…) with any event name

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1686,6 +1686,7 @@ Elm.Native.VirtualDom.make = function(elm) {
     }
 
     // This manages event listeners. Somehow...
+    // Save a reference for use in on(...)
     var delegator = Delegator();
 
     var NativeElement = Elm.Native.Graphics.Element.make(elm);
@@ -1760,6 +1761,8 @@ Elm.Native.VirtualDom.make = function(elm) {
     }
 
     function on(name, decoder, createMessage) {
+        // Ensure we're listening for this type of event
+        delegator.listenTo(name);
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -17,6 +17,7 @@ Elm.Native.VirtualDom.make = function(elm) {
     }
 
     // This manages event listeners. Somehow...
+    // Save a reference for use in on(...)
     var delegator = Delegator();
 
     var NativeElement = Elm.Native.Graphics.Element.make(elm);
@@ -90,6 +91,8 @@ Elm.Native.VirtualDom.make = function(elm) {
     }
 
     function on(name, decoder, createMessage) {
+        // Ensure we're listening for this type of event
+        delegator.listenTo(name);
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {


### PR DESCRIPTION
It looks like the ability to listen for any event got lost again when the events API was rejigged back in elm/html (this commit: evancz/elm-html@ad98d34883892b63e73486cdcab7f96aad3e99d4). It's a useful thing to have for anyone wanting to support touch events, newer browser features, framework integration and so on.
