### PR TITLE
Prevent the default action when an event is cancelled.

### DIFF
--- a/src/VirtualDom.elm
+++ b/src/VirtualDom.elm
@@ -81,7 +81,7 @@ attribute =
 
 -- EVENTS
 
-on : String -> Json.Decoder a -> (a -> Signal.Message) -> Property
+on : String -> Json.Decoder a -> (a -> Maybe Signal.Message) -> Property
 on = Native.VirtualDom.on
 
 

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -96,7 +96,14 @@ Elm.Native.VirtualDom.make = function(elm) {
         function eventHandler(event) {
             var value = A2(Json.runDecoderValue, decoder, event);
             if (value.ctor === 'Ok') {
-                createMessage(value._0)();
+                var message = createMessage(value._0);
+                if (message.ctor !== "Nothing") {
+                    message._0();
+                }
+            }
+            else {
+                event.preventDefault();
+                event.stopPropagation();
             }
         }
         return property(name, DataSetHook(eventHandler));


### PR DESCRIPTION
I'd like to propose a small change to how `on` works with this (incomplete) PR. 

Currently it is not possible to cancel an event, which prevents one from doing things like filtering out keystrokes on input events. I'm proposing that `on` might look like this:

```elm
on : String 
   -> Json.Decoder a               -- When decoder returns Err, the event is cancelled, calling event.preventDefault()
   -> (a -> Maybe Signal.Message)  -- When the function returns Nothing no message is sent
   -> Property
```

Right now I also have this set up that `event.stopPropagation()` is called, to prevent event bubbling when the event is cancelled, but I imagine that there are situations where one would prefer to have fine grained control - this is probably worth discussing.

One objection that might come up is that filtering should happen inside the application logic itself. Even though this is arguably a more elegant API, I don't think that this is appropriate for the native html interface since the html controls already have internal behavior that can only be modified through the event system. Furthermore, it is note clear how one would control event bubbling outside of the event system. My feeling is that specific handlers like `onClick` can remain as simple as `onClick : Signal.Message -> Attribute`, but that `on`, as a building block, should be flexible enough to specify the full behavior.

Another objection that could be raised is that `a -> Maybe Signal.Message` need not be `Maybe` if the user supplies a `NoOp` message type. However, this also makes it very difficult to build new widgets from the old. For example, should you use `on` to filter characters from an input as I've described, this is how you might decide to do it...

```elm
charCode : Json.Decoder (Maybe Char)
charCode = Json.map (Maybe.map fst << String.uncons) ("charCode" := Json.string)

-- Filter out digits
numericInput =
  input
    [ ...
    , on "keypress"
      (Json.customDecoder charCode <| Result.fromMaybe "empty character code") <| \r ->
        case r of
          Err _ -> r
          Ok c  -> if c >= '0' && c <= '9' then Ok c else Err "non-digits are not allowed"
      )
      (always Nothing) -- No message to send, just filter
    ]
```
...forcing a parameter to `numericInput` that handles keystrokes seems somehow overkill.

Please let me know if this PR sounds reasonable.
