### PR TITLE
Prevent mistaken recreation of identical objects

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1123,7 +1123,7 @@ function updateWidget(a, b) {
         if ("name" in a && "name" in b) {
             return a.id === b.id
         } else {
-            return a.init === b.init
+            return a.element.type === b.element.type
         }
     }
 
@@ -1981,3 +1981,4 @@ Elm.Native.VirtualDom.make = function(elm)
 },{"data-set":2,"dom-delegator":8,"vdom/create-element":18,"vdom/patch":24,"vtree/diff":26,"vtree/is-vhook":29,"vtree/vnode":36,"vtree/vtext":38}],40:[function(require,module,exports){
 
 },{}]},{},[39]);
+;

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1981,4 +1981,3 @@ Elm.Native.VirtualDom.make = function(elm)
 },{"data-set":2,"dom-delegator":8,"vdom/create-element":18,"vdom/patch":24,"vtree/diff":26,"vtree/is-vhook":29,"vtree/vnode":36,"vtree/vtext":38}],40:[function(require,module,exports){
 
 },{}]},{},[39]);
-;


### PR DESCRIPTION
This is a candidate fix to address https://github.com/evancz/elm-html/issues/48, a bug in elm-html that inappropriately recreates a canvas every frame because of an issue with virtual-dom's updateWidget, which was comparing the init values for the canvases and deciding they were different and needed to be recreated.

This pull request is my best understanding of the desired check here -- we should be able to call update rather than render iff the two widgets have the same underlying element type, so that's what I check for. This fixes the issue on my project (and 85%+ cpu usage drops down to 25%).