### PR TITLE
Fixes #9 - Virtual DOM updates don't work when embedding Graphics.Element into Html

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1825,17 +1825,20 @@ Elm.Native.VirtualDom.make = function(elm)
 		return new VText(string);
 	}
 
-	function ElementWidget(element) {
+	function ElementWidget(element)
+	{
 		this.element = element;
 	}
 
 	ElementWidget.prototype.type = "Widget";
 
-	ElementWidget.prototype.init = function init() {
+	ElementWidget.prototype.init = function init()
+	{
 		return Element.render(this.element);
 	};
 
-	ElementWidget.prototype.update = function update(previous, node) {
+	ElementWidget.prototype.update = function update(previous, node)
+	{
 		return Element.update(node, previous.element, this.element);
 	};
 

--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1825,21 +1825,23 @@ Elm.Native.VirtualDom.make = function(elm)
 		return new VText(string);
 	}
 
+	function ElementWidget(element) {
+		this.element = element;
+	}
+
+	ElementWidget.prototype.type = "Widget";
+
+	ElementWidget.prototype.init = function init() {
+		return Element.render(this.element);
+	};
+
+	ElementWidget.prototype.update = function update(previous, node) {
+		return Element.update(node, previous.element, this.element);
+	};
+
 	function fromElement(element)
 	{
-		return {
-			type: "Widget",
-
-			element: element,
-
-			init: function () {
-				return Element.render(element);
-			},
-
-			update: function (previous, node) {
-				return Element.update(node, previous.element, element);
-			}
-		};
+		return new ElementWidget(element);
 	}
 
 	function toElement(width, height, html)

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -156,21 +156,23 @@ Elm.Native.VirtualDom.make = function(elm)
 		return new VText(string);
 	}
 
+	function ElementWidget(element) {
+		this.element = element;
+	}
+
+	ElementWidget.prototype.type = "Widget";
+
+	ElementWidget.prototype.init = function init() {
+		return Element.render(this.element);
+	};
+
+	ElementWidget.prototype.update = function update(previous, node) {
+		return Element.update(node, previous.element, this.element);
+	};
+
 	function fromElement(element)
 	{
-		return {
-			type: "Widget",
-
-			element: element,
-
-			init: function () {
-				return Element.render(element);
-			},
-
-			update: function (previous, node) {
-				return Element.update(node, previous.element, element);
-			}
-		};
+		return new ElementWidget(element);
 	}
 
 	function toElement(width, height, html)

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -156,17 +156,20 @@ Elm.Native.VirtualDom.make = function(elm)
 		return new VText(string);
 	}
 
-	function ElementWidget(element) {
+	function ElementWidget(element)
+	{
 		this.element = element;
 	}
 
 	ElementWidget.prototype.type = "Widget";
 
-	ElementWidget.prototype.init = function init() {
+	ElementWidget.prototype.init = function init()
+	{
 		return Element.render(this.element);
 	};
 
-	ElementWidget.prototype.update = function update(previous, node) {
+	ElementWidget.prototype.update = function update(previous, node)
+	{
 		return Element.update(node, previous.element, this.element);
 	};
 


### PR DESCRIPTION
Changed the "fromElement" implementation to use shared "init" and "update" methods
via a prototype. This is because the virtual-dom library expects these methods to
be shared and compares the "init" methods of two embedded widgets to check whether
they're of the same type.

This implementation is likely to be more efficient than the earlier one since each
fromElement call now doesn't create two closures.