### PR TITLE
Fix for nodes requiring setAttributeNS invocation

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -103,7 +103,13 @@ function patchObject(node, props, previous, propName, propValue) {
             if (attrValue === undefined) {
                 node.removeAttribute(attrName)
             } else {
-                node.setAttribute(attrName, attrValue)
+                if (attrName.substring(0, 6) == "xlink:") {
+                    node.setAttributeNS( "http://www.w3.org/1999/xlink", attrName.substring(6), attrValue);
+                } else if (attrName.substring(0, 4) == "xml:") {
+                    el.setAttributeNS(xmlns, attrName.substring(4), attrValue);
+                } else {
+                    node.setAttribute(attrName, attrValue)
+                }
             }
         }
 


### PR DESCRIPTION
Svg xlink attributes do not work in virtual-dom - breaking animation capabilities of Svg.

"xlink:" and "xml:" element attributes require calls to setAttributeNS rather than setAttribute in order to work.

See similar behaviour defined in snap.svg : https://github.com/adobe-webplatform/Snap.svg/blob/master/src/svg.js#L129

This patch mimics the attribute creation of snap.svg.

"xlink:" tested and works, "xml:" untested
