### PR TITLE
Don't move cursor when updating contentEditable nodes

### DIFF
--- a/src/Native/VirtualDom.js
+++ b/src/Native/VirtualDom.js
@@ -1275,14 +1275,25 @@ Elm.Native.VirtualDom.make = function(elm)
 		}
 
 		// ensure that setting text of an input does not move the cursor
-		var useSoftSet =
+		var useSoftSetForInputValue =
 			(name === 'input' || name === 'textarea')
 			&& props.value !== undefined
 			&& !isHook(props.value);
 
-		if (useSoftSet)
+		if (useSoftSetForInputValue)
 		{
 			props.value = SoftSetHook(props.value);
+		}
+ 
+		// ensure that setting innerHTML of a contenteditable node does not move the cursor
+		var useSoftSetForContentEditableInnerHTML =
+			props.contentEditable
+			&& props.innerHTML !== undefined
+			&& !isHook(props.innerHTML);
+
+		if (useSoftSetForContentEditableInnerHTML)
+		{
+			props.innerHTML = SoftSetHook(props.innerHTML);
 		}
 
 		return new VNode(name, props, List.toArray(contents), key, namespace);

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -65,14 +65,25 @@ Elm.Native.VirtualDom.make = function(elm)
 		}
 
 		// ensure that setting text of an input does not move the cursor
-		var useSoftSet =
+		var useSoftSetForInputValue =
 			(name === 'input' || name === 'textarea')
 			&& props.value !== undefined
 			&& !isHook(props.value);
 
-		if (useSoftSet)
+		if (useSoftSetForInputValue)
 		{
 			props.value = SoftSetHook(props.value);
+		}
+ 
+		// ensure that setting innerHTML of a contenteditable node does not move the cursor
+		var useSoftSetForContentEditableInnerHTML =
+			props.contentEditable
+			&& props.innerHTML !== undefined
+			&& !isHook(props.innerHTML);
+
+		if (useSoftSetForContentEditableInnerHTML)
+		{
+			props.innerHTML = SoftSetHook(props.innerHTML);
 		}
 
 		return new VNode(name, props, List.toArray(contents), key, namespace);


### PR DESCRIPTION
Hello! I ran into an issue when using Elm with contenteditable nodes. Specifically, when typing into the contenteditable node, the cursor would jump to the beginning when the element was rebuilt. It appears that this problem had already been solved for inputs and textareas, so it was a simple matter to extend the solution to contenteditable nodes, as well.

Below is an SSCCE to demonstrate the issue.

Steps to reproduce:
1. copy and paste contents below into http://elm-lang.org/try
2. click within the red border
3. hammer away at the keyboard as fast as you can
4. observe the cursor occasionally jumping to the beginning of the field
5. agree that it should stay at the end of the field

``` elm
module Main where

import Html exposing (..)
import Html.Attributes exposing (..)
import Html.Events exposing (..)
import Json.Encode exposing (..)
import Json.Decode exposing (..)
import StartApp.Simple as StartApp
import VirtualDom


innerHtml : String -> Attribute
innerHtml =
  VirtualDom.property "innerHTML" << Json.Encode.string


targetInnerHTML : Json.Decode.Decoder String
targetInnerHTML =
    at ["target", "innerHTML"] Json.Decode.string


view : Signal.Address String -> String -> Html
view address model =
  div []
    [ div
      [ contenteditable True
      , on "input" targetInnerHTML (Signal.message address)
      , innerHtml model
      , style [ ( "border", "10px solid red" ) ]
      ]
      []
    , text model
    ]


main : Signal Html
main = StartApp.start { model = "", update = always << identity, view = view }
```
